### PR TITLE
refact:signin-redirects-and-validations

### DIFF
--- a/app/src/Validators/register.ts
+++ b/app/src/Validators/register.ts
@@ -1,8 +1,14 @@
 import { z } from "zod";
 
 export const registerUserSchema = z.object({
-  userEmail: z.string().email(),
-  password: z.string().min(8).max(16),
+  userEmail: z.string().email({
+    message: "Invalid email",
+  }),
+  password: z.string().min(8, {
+    message: "Password must be atleast 8 characters long"
+  }).max(16, {
+    message: "Password must be atmost 16 characters long"
+  }),
 });
 
 export type RegisterUserRequest = z.infer<typeof registerUserSchema>;

--- a/app/src/components/TranscriptionItem.tsx
+++ b/app/src/components/TranscriptionItem.tsx
@@ -35,6 +35,11 @@ const TranscriptionItem = (props: TranscriptionItemProps) => {
     if (transcription.documentUrl) {
       const audio = new Audio(transcription.documentUrl);
       audioRef.current = audio;
+
+      // Add event listener for 'ended' event
+      audio.addEventListener("ended", () => {
+        setIsPlaying(false);
+      });
     }
 
     // Cleanup function to stop audio playback when component unmounts

--- a/app/src/components/UserForm.tsx
+++ b/app/src/components/UserForm.tsx
@@ -3,7 +3,7 @@
 import { tertiaryFont } from "@/fonts";
 import { cn } from "@/lib/utils";
 import { Input } from "./ui/input";
-import { Button } from "./ui/button";
+import { Button, buttonVariants } from "./ui/button";
 import {
   Form,
   FormControl,
@@ -17,6 +17,7 @@ import { useForm } from "react-hook-form";
 import { RegisterUserRequest, registerUserSchema } from "@/Validators/register";
 
 import { useUser } from "@/hooks/useUser";
+import Link from "next/link";
 
 interface UserFormProps {
   formType: "signin" | "signup";
@@ -37,68 +38,79 @@ const UserForm = (props: UserFormProps) => {
     mode: "all",
   });
 
-
-  const onSubmit = (data: RegisterUserRequest) => {
-    if (formType === "signup")
-      signupUser(data)
-    else
-      //  console.log("Signin User")
-      signinUser(data)
-  };
+  const onSubmit = (data: RegisterUserRequest) => formType === "signup" ? signupUser(data) : signinUser(data);
 
   return (
-    <Form {...form}>
-      <form
-        onSubmit={form.handleSubmit(onSubmit)}
-        className="w-full max-w-sm flex flex-col gap-4 justify-center items-center"
-      >
-        <h1 className={cn(tertiaryFont.className, "text-3xl font-bold")}>
-          {
-            formType === "signup" ? "Sign Up" : "Sign In"
-          }
-        </h1>
-        <div className="grid w-full max-w-sm items-center gap-1.5">
-          <FormField
-            control={form.control}
-            name="userEmail"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Email</FormLabel>
-                <FormControl>
-                  <Input {...field} placeholder="Enter your Email" />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
-        <div className="grid w-full max-w-sm items-center gap-1.5">
-          <FormField
-            control={form.control}
-            name="password"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Password</FormLabel>
-                <FormControl>
-                  <Input {...field} placeholder="Enter your Pasword" />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
-        <Button
-          isLoading={disableSubmit || isPending}
-          disabled={disableSubmit || isPending}
-          type="submit"
-          className="bg-[#668D7E] hover:bg-[#668D7E] text-white w-full"
+    <div className="flex flex-col gap-2 w-full justify-center items-center">
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="w-full max-w-sm flex flex-col gap-4 justify-center items-center"
         >
-          {
-            formType === "signup" ? "Sign Up" : "Sign In"
-          }
-        </Button>
-      </form>
-    </Form>
+          <h1 className={cn(tertiaryFont.className, "text-3xl font-bold")}>
+            {
+              formType === "signup" ? "Sign Up" : "Sign In"
+            }
+          </h1>
+          <div className="grid w-full max-w-sm items-center gap-1.5">
+            <FormField
+              control={form.control}
+              name="userEmail"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="Enter your Email" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div className="grid w-full max-w-sm items-center gap-1.5">
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="password" placeholder="Enter your Pasword" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <Button
+            isLoading={disableSubmit || isPending}
+            disabled={disableSubmit || isPending}
+            type="submit"
+            className="bg-[#668D7E] hover:bg-[#668D7E] text-white w-full"
+          >
+            {
+              formType === "signup" ? "Sign Up" : "Sign In"
+            }
+          </Button>
+        </form>
+      </Form>
+      <div>
+        {formType === "signup" ? "Already have an account?" : "Don't have an account?"}
+        <Link
+          href={formType === "signup" ? "/signin" : "/signup"}
+          aria-disabled={disableSubmit || isPending}
+          className={cn(
+            disableSubmit || isPending ? 'pointer-events-none' : '',
+            buttonVariants({
+              variant: "link",
+              className: "text-[#668D7E] hover:text-[#668D7E] font-bold"
+            }
+            ))}
+        >
+          {formType === "signup" ? "Sign In" : "Sign Up"}
+        </Link>
+      </div>
+    </div>
   );
 };
 

--- a/app/src/components/ui/input.tsx
+++ b/app/src/components/ui/input.tsx
@@ -1,25 +1,41 @@
 import * as React from "react";
-
+import { useState } from "react";
 import { cn } from "@/lib/utils";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
-    return (
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const togglePasswordVisibility = () => {
+    setShowPassword((prev) => !prev);
+  };
+
+  return (
+    <div className="relative w-full">
       <input
-        type={type}
+        type={type === "password" && showPassword ? "text" : type}
         className={cn(
           "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
-          className,
+          className
         )}
         ref={ref}
         {...props}
       />
-    );
-  },
-);
+      {type === "password" && (
+        <button
+          type="button"
+          onClick={togglePasswordVisibility}
+          className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500"
+        >
+          {showPassword ? <EyeIcon className="h-5 w-5" /> : <EyeOffIcon className="h-5 w-5" />}
+        </button>
+      )}
+    </div>
+  );
+});
+
 Input.displayName = "Input";
 
 export { Input };

--- a/app/src/hooks/useUser.ts
+++ b/app/src/hooks/useUser.ts
@@ -20,7 +20,7 @@ export const useUser = () => {
         },
         onSuccess: async (res) => {
           toast.success("User Registered Successfully");
-          router.push("/")
+          router.push("/new")
         },
         onError: (error) => {
           if (error instanceof AxiosError) {
@@ -55,7 +55,7 @@ export const useUser = () => {
       },
       onSuccess: async (res) => {
         toast.success("User sign in Successfull");
-        router.push("/")
+        router.push("/new")
       },
       onError: (error) => {
         if (error instanceof AxiosError) {


### PR DESCRIPTION
- default redirects to `/new` page after `signin` and `signup`
- added better validations errors for password and emails 
- added an toggle to hide an view password defaults to 'hidden'

Closes #27 
