### PR TITLE
refact: public route for transcriptions

### DIFF
--- a/app/src/app/transcriptions/[transcription_id]/page.tsx
+++ b/app/src/app/transcriptions/[transcription_id]/page.tsx
@@ -23,9 +23,7 @@ interface PageProps {
 const page = async (props: PageProps) => {
   const { transcription_id } = props.params;
 
-  const { user } = await validateRequest();
-
-  if (!user) return redirect("/signin");
+  // skip user signin validation for now
 
   const transcription = await db
     .select()

--- a/app/src/app/transcriptions/page.tsx
+++ b/app/src/app/transcriptions/page.tsx
@@ -18,10 +18,7 @@ export const metadata: Metadata = {
 
 const page = async () => {
 
-  const {user} = await validateRequest();
-
-  if (!user) return redirect("/signin");
-
+  // skip user signin validation for now
 
   const userTranscriptions = await db
     .select({


### PR DESCRIPTION
Closes #37 

skips user sign in validation and redirect from `/transcriptions` and `/transcriptions/[:id]`