### PR TITLE
fix[uploadthing]: max file size mismatch

### DIFF
--- a/app/src/app/api/uploadthing/core.ts
+++ b/app/src/app/api/uploadthing/core.ts
@@ -12,9 +12,11 @@ export const ourFileRouter = {
     {
       audio: {
         maxFileCount: 1,
+        maxFileSize: "1024MB"
       },
       video: {
         maxFileCount: 1,
+        maxFileSize: "1024MB"
       }
     })
     // Set permissions and file types for this FileRoute


### PR DESCRIPTION
Fixes #44 

Added maxFile Size as 1GB // 1024MB
to override the default maxFileSize of uploadthing