### PR TITLE
Refactor/file validation and not found page

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -44,6 +44,7 @@
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "uploadthing": "^6.13.2",
+        "uuid": "^11.0.3",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -9059,6 +9060,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -45,6 +45,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "uploadthing": "^6.13.2",
+    "uuid": "^11.0.3",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/app/src/app/api/uploadthing/core.ts
+++ b/app/src/app/api/uploadthing/core.ts
@@ -12,11 +12,11 @@ export const ourFileRouter = {
     {
       audio: {
         maxFileCount: 1,
-        maxFileSize: "1024MB"
+        maxFileSize: "16MB"
       },
       video: {
         maxFileCount: 1,
-        maxFileSize: "1024MB"
+        maxFileSize: "16MB"
       }
     })
     // Set permissions and file types for this FileRoute

--- a/app/src/app/transcriptions/[transcription_id]/page.tsx
+++ b/app/src/app/transcriptions/[transcription_id]/page.tsx
@@ -1,14 +1,12 @@
-// transcriptions / [transcription_id] / page.tsx
-
 import { validateRequest } from "@/auth";
 import DetailedTranscription from "@/components/DetailedTranscription";
 import NavigateBack from "@/components/NavigateBack";
 import { db } from "@/db";
 import { transcriptions } from "@/db/schema";
 import { eq } from "drizzle-orm";
-
 import { Metadata } from "next";
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
+import { validate as validateUUID } from 'uuid';
 
 export const metadata: Metadata = {
   title: "Lingo.ai | Transcription",
@@ -23,6 +21,10 @@ interface PageProps {
 const page = async (props: PageProps) => {
   const { transcription_id } = props.params;
 
+  if (!validateUUID(transcription_id)) {
+    return notFound();
+  }
+
   // skip user signin validation for now
 
   const transcription = await db
@@ -30,8 +32,12 @@ const page = async (props: PageProps) => {
     .from(transcriptions)
     .where(eq(transcriptions.id, transcription_id));
 
-  return (
 
+  if (transcription.length === 0) {
+    return notFound();
+  }
+
+  return (
     <div className="flex flex-col w-full h-full pt-8">
       <div className="flex justify-start w-full mb-8">
         <NavigateBack href="/transcriptions" subHeading={`Transcription for ${transcription[0].documentName}`} />

--- a/app/src/components/RecorderCard.tsx
+++ b/app/src/components/RecorderCard.tsx
@@ -26,7 +26,7 @@ import { Fragment } from "react";
 interface RecorderCardProps {
   userId: string;
 }
-const RecorderCard = (props:RecorderCardProps) => {
+const RecorderCard = (props: RecorderCardProps) => {
   const { userId } = props;
 
   const router = useRouter();
@@ -51,15 +51,41 @@ const RecorderCard = (props:RecorderCardProps) => {
     }
   };
 
+  const handleFileError = (file: any) => {
+    file.errors.forEach((error: any) => {
+      switch (error.code) {
+        case "file-too-large":
+          toast.error(`File ${file.file.name} is too large`, {
+            description: "Please upload a file less than 5MB",
+          });
+          break;
+        case "file-invalid-type":
+          toast.error(`File ${file.file.name} is invalid`, {
+            description: "Please upload a valid audio or video file",
+          });
+          break;
+        default:
+          toast.error(`File ${file.file.name} encountered an error`, {
+            description: error.message,
+          });
+          break;
+      }
+    });
+  };
+
   const { getRootProps, getInputProps } = useDropzone({
     maxFiles: 1,
-    // maxSize: 5 * 1024 * 1024, // 5MB
-    onDrop: handleFileChange,
+    maxSize: 5 * 1024 * 1024, // 5MB
+    onDrop: (acceptedFiles, rejectedFiles) => {
+      if (rejectedFiles.length > 0) {
+        rejectedFiles.forEach(handleFileError);
+      }
+      handleFileChange(acceptedFiles);
+    },
     accept: {
       "audio/*": [".mp3", ".wav"],
       "video/*": [".mp4"],
     },
-    onDropRejected: (error) => console.log(error),
     noDrag: true,
   });
 
@@ -137,7 +163,7 @@ const RecorderCard = (props:RecorderCardProps) => {
         return response.data[0] as TranscriptionsType;
       },
       onSuccess: async (res) => {
-        if(res.id){
+        if (res.id) {
           router.push(`/transcriptions/${res.id}`);
         }
         return toast.success("Transcription saved successfully");
@@ -286,9 +312,14 @@ const RecorderCard = (props:RecorderCardProps) => {
                       <p className="mt-2">{formatTime(recordingTime)}</p>
                     </div>
                   ) : (
-                    <p>
-                      Enable mic access, record yourself, or upload an audio or video file
-                    </p>
+                    <>
+                      <p>
+                        Enable mic access, record yourself, or upload an audio or video file
+                      </p>
+                      <p className="text-gray-400 text-sm">
+                        Max file size: 5MB
+                      </p>
+                    </>
                   )}
                 </Fragment>
               )}

--- a/app/src/components/TranscriptionItem.tsx
+++ b/app/src/components/TranscriptionItem.tsx
@@ -27,7 +27,6 @@ const TranscriptionItem = (props: TranscriptionItemProps) => {
   const [defaultTranscriptionFilter, setDefaultTranscriptionFilter] = useState<boolean>(false);
   const [filteredTranscriptions, setFilteredTranscriptions] = useState(userTranscriptions);
 
-  console.log({ userTranscriptions }, { filteredTranscriptions }, { defaultTranscriptionFilter });
 
   useEffect(() => {
     if (defaultTranscriptionFilter) {


### PR DESCRIPTION
This PR addresses the following
- adds file Validation of 5MB for audio and Video Files
- also fixes the issue where invalid UUIDs for `transcription_id` were causing errors on the transcription page.

The following changes have been implemented:

### Changes Made
- **File Size**: Added Max File Size of 5MB and added error toast for the same
- **UUID Validation**: Added validation for `transcription_id` to ensure it is a valid UUID before making the database query.
- **Error Handling**: If the `transcription_id` is invalid, the page now returns a `notFound` response.
- **Code Refactoring**: Improved code readability and maintainability.

### Changes Summary
- Added File Validations
- Added UUID validation for `transcription_id`.
- Returns a `notFound` response for invalid `transcription_id`.
- Proceeds with the database query only if `transcription_id` is valid.

## Linked Issues
- Closes #51 
- Closes #50 