### PR TITLE
chore: upgrade to aws rds

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
     "@lucia-auth/adapter-drizzle": "^1.1.0",
-    "@neondatabase/serverless": "^0.9.4",
     "@node-rs/argon2": "^1.8.3",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
@@ -34,6 +33,7 @@
     "lucide-react": "^0.437.0",
     "next": "15.1.6",
     "next-themes": "^0.3.0",
+    "pg": "^8.13.3",
     "postgres": "^3.4.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@types/node": "^20",
+    "@types/pg": "^8.11.11",
     "@types/react": "19.0.8",
     "@types/react-dom": "19.0.3",
     "drizzle-kit": "^0.24.2",

--- a/app/src/db/index.ts
+++ b/app/src/db/index.ts
@@ -1,8 +1,16 @@
-import { neon } from "@neondatabase/serverless";
-import { drizzle } from "drizzle-orm/neon-http";
+import { drizzle } from 'drizzle-orm/node-postgres'
+import { Client } from 'pg'
+import * as schema from './schema'
+
 
 if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL is not set");
 }
-const sql = neon(process.env.DATABASE_URL);
-export const db = drizzle(sql);
+
+const client = new Client({
+  connectionString: process.env.DATABASE_URL,
+  // ssl: { rejectUnauthorized: false }
+})
+await client.connect()
+
+export const db = drizzle(client, { schema })


### PR DESCRIPTION
updates the drizzle orm configuration for generic pg connector instead of neon db connector

also removes `neondatabase/serverless` package