### PR TITLE
reafact(drizzle-connector): pg pooled connection

### DIFF
--- a/app/src/db/index.ts
+++ b/app/src/db/index.ts
@@ -1,5 +1,5 @@
 import { drizzle } from 'drizzle-orm/node-postgres'
-import { Client } from 'pg'
+import { Pool } from 'pg'
 import * as schema from './schema'
 
 
@@ -7,10 +7,8 @@ if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL is not set");
 }
 
-const client = new Client({
+const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  // ssl: { rejectUnauthorized: false }
 })
-await client.connect()
 
-export const db = drizzle(client, { schema })
+export const db = drizzle(pool, { schema })

--- a/app/src/db/index.ts
+++ b/app/src/db/index.ts
@@ -9,6 +9,9 @@ if (!process.env.DATABASE_URL) {
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
+  max: 10, // max 10 connections
+  idleTimeoutMillis: 30000, // idle connections are closed after 30s
+  connectionTimeoutMillis: 2000, // wait 2s for a connection before failing
 })
 
 export const db = drizzle(pool, { schema })


### PR DESCRIPTION
## Replace client with connection pool

### Changes
- Replace `Client` with `Pool` from 'pg' for better connection management
- Remove manual `client.connect()` call as pools handle connections automatically
- Maintain same Drizzle ORM configuration