### PR TITLE
Integrate Zaban STT/TTS/TRANSLATE API for audio translation and text translation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - ./service/.env
     depends_on:
       - ollama
+      - redis
     ports:
       - "8000:8000"
     volumes:
@@ -53,6 +54,13 @@ services:
       - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
+
+  redis:
+    container_name: lingo-redis
+    image: redis:latest
+    restart: always
+    ports:
+      - "6379:6379"
 
 secrets:
   db_user:

--- a/service/.env.example
+++ b/service/.env.example
@@ -19,3 +19,7 @@ DB_PASSWORD=password
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=lingo
+
+# Zaban STT/TTS API (optional; used for upload STT and TTS)
+ZABAN_BASE_URL=http://localhost:8000
+ZABAN_API_KEY=

--- a/service/audio_service.py
+++ b/service/audio_service.py
@@ -34,6 +34,7 @@ from fastapi import  HTTPException, UploadFile
 import openai
 from dotenv import load_dotenv
 from config import openai_api_key, model_id, model_path, zaban_base_url, zaban_api_key
+from constants import ZABAN_LANG_TO_CODE, ZABAN_API_PATH_STT, ZABAN_STT_MODEL
 from load_model import load_model
 import logging
 import whisper_timestamped as whisper_ts
@@ -41,14 +42,6 @@ import requests
 from urllib.parse import urlparse
 import tempfile
 import os
-
-# Map Zaban/BCP-47 language codes to short codes (e.g. hin_Deva -> hi)
-ZABAN_LANG_TO_CODE = {
-    "hin_Deva": "hi", "eng_Latn": "en", "ben_Beng": "bn", "tam_Taml": "ta",
-    "tel_Telu": "te", "mar_Deva": "mr", "mal_Mlym": "ml", "kan_Knda": "kn",
-    "guj_Gujr": "gu", "pan_Guru": "pa", "ory_Orya": "or", "urd_Arab": "ur",
-    "san_Deva": "sa",
-}
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -186,13 +179,13 @@ def translate_with_whisper_from_upload(upload_file: UploadFile):
         if not temp_file_path:
             return (None, [None, "Unclear command"], [None, "en"], None)
 
-        url = f"{zaban_base_url.rstrip('/')}/api/v1/stt"
+        url = f"{zaban_base_url.rstrip('/')}{ZABAN_API_PATH_STT}"
         headers = {}
         if zaban_api_key:
             headers["X-API-Key"] = zaban_api_key
         with open(temp_file_path, "rb") as audio_file:
             files = {"audio": (upload_file.filename or "audio.wav", audio_file, "audio/wav")}
-            data = {"model": "whisper"}
+            data = {"model": ZABAN_STT_MODEL}
             r = requests.post(url, files=files, data=data, headers=headers, timeout=60)
         r.raise_for_status()
         result = r.json()

--- a/service/audio_service.py
+++ b/service/audio_service.py
@@ -100,12 +100,18 @@ def translate_with_whisper(audioPath):
         )
 
 # Transcribe via Zaban STT (model=whisper) with segment timestamps. Used for URL audio.
-def translate_with_whisper_timestamped(audio_url: str):
-    """Transcribe audio from URL via Zaban STT: send link directly (no download). Returns text, segments, detected_language."""
+def translate_with_whisper_timestamped(audio_url: str, translate_to_english: bool = True):
+    """
+    Transcribe audio from URL via Zaban STT: send link directly (no download).
+
+    By default, uses `translate_to_english=True` to mirror previous whisper_ts behaviour:
+    English text + segment timestamps, while still allowing callers to opt-out.
+    Returns dict with text, segments, detected_language.
+    """
     logger.info("Transcription started (Zaban)")
     try:
         validate_audio_url(audio_url)
-        return _transcribe_with_zaban_by_url(audio_url)
+        return _transcribe_with_zaban_by_url(audio_url, translate_to_english=translate_to_english)
     except HTTPException:
         raise
     except requests.RequestException as e:
@@ -154,10 +160,20 @@ def _normalize_segments(segments: list) -> list:
     return out
 
 
-def _parse_zaban_stt_response(result: dict) -> dict:
-    """Parse Zaban STT JSON response into unified dict with text, segments, detected_language, language."""
-    text = result.get("text", "").strip() or ""
-    raw_lang = result.get("language", "en")
+def _parse_zaban_stt_response(result: dict, translate_to_english: bool = False) -> dict:
+    """
+    Parse Zaban STT JSON response into unified dict with text, segments, detected_language, language.
+
+    When translate_to_english is True and the backend returns `translated_text` / `target_lang`,
+    we surface the English translation as `text` to preserve previous whisper_ts behaviour.
+    """
+    if translate_to_english and result.get("translated_text"):
+        # Prefer translated text and target language if available
+        text = result.get("translated_text", "").strip() or result.get("text", "").strip() or ""
+        raw_lang = result.get("target_lang", "eng_Latn")
+    else:
+        text = result.get("text", "").strip() or ""
+        raw_lang = result.get("language", "en")
     lang_code = _zaban_lang_to_code(raw_lang)
     segments = _normalize_segments(result.get("segments", []))
     return {
@@ -168,7 +184,7 @@ def _parse_zaban_stt_response(result: dict) -> dict:
     }
 
 
-def _transcribe_with_zaban_by_url(audio_url: str) -> dict:
+def _transcribe_with_zaban_by_url(audio_url: str, translate_to_english: bool = True) -> dict:
     """
     Transcribe audio via Zaban STT by sending the audio URL (no download).
     POST JSON with audio_url and model=whisper. Returns same shape as _transcribe_with_zaban.
@@ -177,14 +193,19 @@ def _transcribe_with_zaban_by_url(audio_url: str) -> dict:
     headers = {"Content-Type": "application/json"}
     if zaban_api_key:
         headers["X-API-Key"] = zaban_api_key
-    payload = {"audio_url": audio_url, "model": ZABAN_STT_MODEL}
+    payload = {
+        "audio_url": audio_url,
+        "model": ZABAN_STT_MODEL,
+        # Preserve previous whisper_ts semantics: translate to English by default
+        "translate_to_english": translate_to_english,
+    }
     r = requests.post(url, json=payload, headers=headers, timeout=300)
     r.raise_for_status()
     result = r.json()
-    return _parse_zaban_stt_response(result)
+    return _parse_zaban_stt_response(result, translate_to_english=translate_to_english)
 
 
-def _transcribe_with_zaban(audio_path: str, filename: str = "audio.wav") -> dict:
+def _transcribe_with_zaban(audio_path: str, filename: str = "audio.wav", translate_to_english: bool = True) -> dict:
     """
     Transcribe audio file via Zaban STT (model=whisper). Used for upload flow.
     Returns dict with text, segments (whisper-style timestamps), detected_language.
@@ -195,15 +216,19 @@ def _transcribe_with_zaban(audio_path: str, filename: str = "audio.wav") -> dict
         headers["X-API-Key"] = zaban_api_key
     with open(audio_path, "rb") as audio_file:
         files = {"audio": (filename, audio_file, "audio/wav")}
-        data = {"model": ZABAN_STT_MODEL}
+        data = {
+            "model": ZABAN_STT_MODEL,
+            # For upload flow we default to transcription-only unless explicitly changed
+            "translate_to_english": str(translate_to_english).lower(),
+        }
         r = requests.post(url, files=files, data=data, headers=headers, timeout=300)
     r.raise_for_status()
     result = r.json()
-    return _parse_zaban_stt_response(result)
+    return _parse_zaban_stt_response(result, translate_to_english=translate_to_english)
 
 
 def translate_with_whisper_from_upload(upload_file: UploadFile):
-    """Transcribe uploaded audio via Zaban STT (whisper timestamps). Returns (id, [_, text], [_, lang_code], _) for main.py compatibility."""
+    """Transcribe uploaded audio via Zaban STT (English + whisper timestamps). Returns (id, [_, text], [_, lang_code], _) for main.py compatibility."""
     logger.info("STT from upload started (Zaban)")
     temp_file_path = None
     try:
@@ -221,7 +246,7 @@ def translate_with_whisper_from_upload(upload_file: UploadFile):
         if not temp_file_path:
             return (None, [None, "Unclear command"], [None, "en"], None)
 
-        data = _transcribe_with_zaban(temp_file_path, upload_file.filename or "audio.wav")
+        data = _transcribe_with_zaban(temp_file_path, upload_file.filename or "audio.wav", translate_to_english=True)
         text = data["text"] or "Unclear command"
         lang_code = data["language"]
         return (None, [None, text], [None, lang_code], None)

--- a/service/audio_service.py
+++ b/service/audio_service.py
@@ -37,7 +37,6 @@ from config import openai_api_key, model_id, model_path, zaban_base_url, zaban_a
 from constants import ZABAN_LANG_TO_CODE, ZABAN_API_PATH_STT, ZABAN_STT_MODEL
 from load_model import load_model
 import logging
-import whisper_timestamped as whisper_ts
 import requests
 from urllib.parse import urlparse
 import tempfile
@@ -100,48 +99,26 @@ def translate_with_whisper(audioPath):
             detail=f"Translation failed: {str(e)}"
         )
 
-#translate the audio file to English language using whisper timestamp model
-def translate_with_whisper_timestamped(audioPath):
-    """Translate audio file to English language using whisper timestamp model."""
-    logger.info("Translation started")
+# Transcribe via Zaban STT (model=whisper) with segment timestamps. Used for URL audio.
+def translate_with_whisper_timestamped(audio_url: str):
+    """Transcribe audio from URL via Zaban STT: send link directly (no download). Returns text, segments, detected_language."""
+    logger.info("Transcription started (Zaban)")
     try:
-        validate_audio_url(audioPath)
-        options = dict(beam_size=5, best_of=5, temperature=(0.0, 0.2, 0.4, 0.6, 0.8, 1.0))
-        translate_options = dict(task="translate", **options)
-        result = whisper_ts.transcribe_timestamped(
-            model,
-            audioPath,            
-            condition_on_previous_text=False,
-            vad=False,
-            trust_whisper_timestamps=False,
-            **translate_options
-        )
-        
-        # Extract detected language
-        detected_language = (
-            result.get('language') or 
-            result.get('detected_language') or 
-            'unknown'
-        )
-        
-        # Check if language_probs exists
-        if 'language_probs' in result:
-            logger.info("Language probabilities: %s", result['language_probs'])
-        
-        return {
-            "text": result.get("text", ""),
-            "segments": result.get("segments", []),
-            "detected_language": detected_language,
-            "transcription_result": result
-        }
-        
+        validate_audio_url(audio_url)
+        return _transcribe_with_zaban_by_url(audio_url)
     except HTTPException:
         raise
+    except requests.RequestException as e:
+        logger.error(f"Zaban STT request failed: {str(e)}")
+        raise HTTPException(
+            status_code=502,
+            detail=f"Transcription failed: {str(e)}"
+        )
     except Exception as e:
-        logger.error(f"Translation failed: {str(e)}")
+        logger.error(f"Transcription failed: {str(e)}")
         raise HTTPException(
             status_code=500,
-            detail=f"Translation failed: {str(e)}"
+            detail=f"Transcription failed: {str(e)}"
         )
 
 def _zaban_lang_to_code(lang: str) -> str:
@@ -160,8 +137,73 @@ def _zaban_lang_to_code(lang: str) -> str:
     return "en"
 
 
+def _normalize_segments(segments: list) -> list:
+    """Normalize Zaban/whisper segments to {start, end, text}."""
+    if not segments:
+        return []
+    out = []
+    for s in segments:
+        if isinstance(s, dict):
+            out.append({
+                "start": float(s.get("start", 0)),
+                "end": float(s.get("end", 0)),
+                "text": s.get("text", ""),
+            })
+        else:
+            out.append({"start": 0.0, "end": 0.0, "text": str(s)})
+    return out
+
+
+def _parse_zaban_stt_response(result: dict) -> dict:
+    """Parse Zaban STT JSON response into unified dict with text, segments, detected_language, language."""
+    text = result.get("text", "").strip() or ""
+    raw_lang = result.get("language", "en")
+    lang_code = _zaban_lang_to_code(raw_lang)
+    segments = _normalize_segments(result.get("segments", []))
+    return {
+        "text": text,
+        "segments": segments,
+        "detected_language": raw_lang,
+        "language": lang_code,
+    }
+
+
+def _transcribe_with_zaban_by_url(audio_url: str) -> dict:
+    """
+    Transcribe audio via Zaban STT by sending the audio URL (no download).
+    POST JSON with audio_url and model=whisper. Returns same shape as _transcribe_with_zaban.
+    """
+    url = f"{zaban_base_url.rstrip('/')}{ZABAN_API_PATH_STT}"
+    headers = {"Content-Type": "application/json"}
+    if zaban_api_key:
+        headers["X-API-Key"] = zaban_api_key
+    payload = {"audio_url": audio_url, "model": ZABAN_STT_MODEL}
+    r = requests.post(url, json=payload, headers=headers, timeout=300)
+    r.raise_for_status()
+    result = r.json()
+    return _parse_zaban_stt_response(result)
+
+
+def _transcribe_with_zaban(audio_path: str, filename: str = "audio.wav") -> dict:
+    """
+    Transcribe audio file via Zaban STT (model=whisper). Used for upload flow.
+    Returns dict with text, segments (whisper-style timestamps), detected_language.
+    """
+    url = f"{zaban_base_url.rstrip('/')}{ZABAN_API_PATH_STT}"
+    headers = {}
+    if zaban_api_key:
+        headers["X-API-Key"] = zaban_api_key
+    with open(audio_path, "rb") as audio_file:
+        files = {"audio": (filename, audio_file, "audio/wav")}
+        data = {"model": ZABAN_STT_MODEL}
+        r = requests.post(url, files=files, data=data, headers=headers, timeout=300)
+    r.raise_for_status()
+    result = r.json()
+    return _parse_zaban_stt_response(result)
+
+
 def translate_with_whisper_from_upload(upload_file: UploadFile):
-    """Transcribe uploaded audio via Zaban STT. Returns (id, [_, text], [_, lang_code], _) for main.py compatibility."""
+    """Transcribe uploaded audio via Zaban STT (whisper timestamps). Returns (id, [_, text], [_, lang_code], _) for main.py compatibility."""
     logger.info("STT from upload started (Zaban)")
     temp_file_path = None
     try:
@@ -179,20 +221,9 @@ def translate_with_whisper_from_upload(upload_file: UploadFile):
         if not temp_file_path:
             return (None, [None, "Unclear command"], [None, "en"], None)
 
-        url = f"{zaban_base_url.rstrip('/')}{ZABAN_API_PATH_STT}"
-        headers = {}
-        if zaban_api_key:
-            headers["X-API-Key"] = zaban_api_key
-        with open(temp_file_path, "rb") as audio_file:
-            files = {"audio": (upload_file.filename or "audio.wav", audio_file, "audio/wav")}
-            data = {"model": ZABAN_STT_MODEL}
-            r = requests.post(url, files=files, data=data, headers=headers, timeout=60)
-        r.raise_for_status()
-        result = r.json()
-        text = result.get("text", "").strip() or "Unclear command"
-        raw_lang = result.get("language", "en")
-        lang_code = _zaban_lang_to_code(raw_lang)
-        # main.py expects: id, response, lang, dia = ...; response[1] = text; lang[1] = language
+        data = _transcribe_with_zaban(temp_file_path, upload_file.filename or "audio.wav")
+        text = data["text"] or "Unclear command"
+        lang_code = data["language"]
         return (None, [None, text], [None, lang_code], None)
     except requests.RequestException as e:
         logger.error(f"Zaban STT request failed: {str(e)}")

--- a/service/audio_service.py
+++ b/service/audio_service.py
@@ -33,7 +33,7 @@ from scipy import misc
 from fastapi import  HTTPException, UploadFile
 import openai
 from dotenv import load_dotenv
-from config import openai_api_key, model_id, model_path
+from config import openai_api_key, model_id, model_path, zaban_base_url, zaban_api_key
 from load_model import load_model
 import logging
 import whisper_timestamped as whisper_ts
@@ -41,7 +41,14 @@ import requests
 from urllib.parse import urlparse
 import tempfile
 import os
-from detect_intent import client
+
+# Map Zaban/BCP-47 language codes to short codes (e.g. hin_Deva -> hi)
+ZABAN_LANG_TO_CODE = {
+    "hin_Deva": "hi", "eng_Latn": "en", "ben_Beng": "bn", "tam_Taml": "ta",
+    "tel_Telu": "te", "mar_Deva": "mr", "mal_Mlym": "ml", "kan_Knda": "kn",
+    "guj_Gujr": "gu", "pan_Guru": "pa", "ory_Orya": "or", "urd_Arab": "ur",
+    "san_Deva": "sa",
+}
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -144,9 +151,25 @@ def translate_with_whisper_timestamped(audioPath):
             detail=f"Translation failed: {str(e)}"
         )
 
+def _zaban_lang_to_code(lang: str) -> str:
+    """Normalize Zaban/BCP-47 language to short code (e.g. hin_Deva -> hi)."""
+    if not lang:
+        return "en"
+    key = lang.strip()
+    if key in ZABAN_LANG_TO_CODE:
+        return ZABAN_LANG_TO_CODE[key]
+    if len(key) <= 3:
+        return key
+    # BCP-47 style: take first 2 chars of script part (e.g. hin_Deva -> hin -> hi)
+    prefix = key.split("_")[0]
+    if len(prefix) >= 2:
+        return prefix[:2]
+    return "en"
+
+
 def translate_with_whisper_from_upload(upload_file: UploadFile):
-    """Translate uploaded audio file to English language using whisper model (without timestamps)."""
-    logger.info("Translation from upload started")
+    """Transcribe uploaded audio via Zaban STT. Returns (id, [_, text], [_, lang_code], _) for main.py compatibility."""
+    logger.info("STT from upload started (Zaban)")
     temp_file_path = None
     try:
         # Create a temporary file with the original file extension
@@ -160,20 +183,30 @@ def translate_with_whisper_from_upload(upload_file: UploadFile):
             temp_file.write(content)
             temp_file.flush()
 
-        '''options = dict(beam_size=5, best_of=5)
-        translate_options = dict(task="translate", **options)
-        result = model.transcribe(temp_file_path, **translate_options,prompt="Only Indian langues,like, hindi, marthi,tamil,gujarti,telegu,bengali,panjabi,bengali,malayalam,kannada or Indian english voice is used as voice banking service. voice will be like, check balance, pay money to some Indian names, list of beneficiaries, transactions list or ask for transaction insights. Do not translitarate, translate to English words, do not mix other language words")
-        return result'''
-        if temp_file_path:
-            with open(temp_file_path, "rb") as audio_file:
-                response = client.speech_to_text.translate(
-                file=audio_file,
-                model="saaras:v2.5",
-                prompt="Voice Banking"
-            )
-        else:
-            repsonse = "Unclear command"
-        return response
+        if not temp_file_path:
+            return (None, [None, "Unclear command"], [None, "en"], None)
+
+        url = f"{zaban_base_url.rstrip('/')}/api/v1/stt"
+        headers = {}
+        if zaban_api_key:
+            headers["X-API-Key"] = zaban_api_key
+        with open(temp_file_path, "rb") as audio_file:
+            files = {"audio": (upload_file.filename or "audio.wav", audio_file, "audio/wav")}
+            data = {"model": "whisper"}
+            r = requests.post(url, files=files, data=data, headers=headers, timeout=60)
+        r.raise_for_status()
+        result = r.json()
+        text = result.get("text", "").strip() or "Unclear command"
+        raw_lang = result.get("language", "en")
+        lang_code = _zaban_lang_to_code(raw_lang)
+        # main.py expects: id, response, lang, dia = ...; response[1] = text; lang[1] = language
+        return (None, [None, text], [None, lang_code], None)
+    except requests.RequestException as e:
+        logger.error(f"Zaban STT request failed: {str(e)}")
+        raise HTTPException(
+            status_code=502,
+            detail=f"Speech-to-text failed: {str(e)}"
+        )
     except Exception as e:
         logger.error(f"Translation from upload failed: {str(e)}")
         raise HTTPException(

--- a/service/audio_service.py
+++ b/service/audio_service.py
@@ -164,16 +164,16 @@ def _parse_zaban_stt_response(result: dict, translate_to_english: bool = False) 
     """
     Parse Zaban STT JSON response into unified dict with text, segments, detected_language, language.
 
-    When translate_to_english is True and the backend returns `translated_text` / `target_lang`,
-    we surface the English translation as `text` to preserve previous whisper_ts behaviour.
+    When translate_to_english is True we use translated_text as text (English), but we always use
+    the detected (source) language for detected_language and language so downstream (intent,
+    session, response translation) get the user's spoken language.
     """
     if translate_to_english and result.get("translated_text"):
-        # Prefer translated text and target language if available
         text = result.get("translated_text", "").strip() or result.get("text", "").strip() or ""
-        raw_lang = result.get("target_lang", "eng_Latn")
     else:
         text = result.get("text", "").strip() or ""
-        raw_lang = result.get("language", "en")
+    # Always use detected (source) language for lang_code and detected_language, not target_lang
+    raw_lang = result.get("language", "en")
     lang_code = _zaban_lang_to_code(raw_lang)
     segments = _normalize_segments(result.get("segments", []))
     return {

--- a/service/config.py
+++ b/service/config.py
@@ -18,7 +18,10 @@ db_host = os.getenv("DB_HOST")
 db_port = os.getenv("DB_PORT")
 db_name = os.getenv("DB_NAME")
 
-sarvam_api_key = os.getenv("SARVAM_API_KEY","")
+# Zaban STT/TTS API (replaces Sarvam for speech). Use https to avoid redirect (POST→GET causes 405).
+zaban_base_url = os.getenv("ZABAN_BASE_URL", "")
+zaban_api_key = os.getenv("ZABAN_API_KEY", "")
+
 # Redis configuration
 redis_host = os.getenv("REDIS_HOST", "localhost")
 redis_port = int(os.getenv("REDIS_PORT", 6379))

--- a/service/constants.py
+++ b/service/constants.py
@@ -1,0 +1,22 @@
+# Zaban API path segments (base URL from config). Model name for STT.
+ZABAN_API_PATH_STT = "/api/v1/stt"
+ZABAN_API_PATH_TRANSLATE = "/api/v1/translate"
+ZABAN_STT_MODEL = "whisper"
+
+# Single source of truth: Zaban/BCP-47 -> short code. Reverse (short -> BCP-47)
+ZABAN_LANG_TO_CODE = {
+    "hin_Deva": "hi", "eng_Latn": "en", "ben_Beng": "bn", "tam_Taml": "ta",
+    "tel_Telu": "te", "mar_Deva": "mr", "mal_Mlym": "ml", "kan_Knda": "kn",
+    "guj_Gujr": "gu", "pan_Guru": "pa", "ory_Orya": "or", "urd_Arab": "ur",
+    "san_Deva": "sa", "asm_Beng": "as",
+}
+
+# Short language code -> display name
+LANG_MAP = {
+    "en": "English", "hi": "Hindi", "bn": "Bengali", "ta": "Tamil", "te": "Telugu",
+    "mr": "Marathi", "ml": "Malayalam", "kn": "Kannada", "gu": "Gujarati", "pa": "Punjabi",
+    "or": "Odia", "ur": "Urdu", "sa": "Sanskrit", "ar": "Arabic", "fr": "French",
+    "de": "German", "es": "Spanish", "it": "Italian", "pt": "Portuguese", "zh": "Chinese",
+    "ja": "Japanese", "ko": "Korean", "ru": "Russian", "sv": "Swedish", "pl": "Polish",
+    "tr": "Turkish", "cs": "Czech", "fi": "Finnish", "he": "Hebrew",
+}

--- a/service/detect_intent.py
+++ b/service/detect_intent.py
@@ -11,22 +11,12 @@ from time_utils import normalize_timeframe
 import requests
 import os
 
+from constants import ZABAN_LANG_TO_CODE, ZABAN_API_PATH_TRANSLATE
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
-lang_map = {
-    "en": "English", "hi": "Hindi", "bn": "Bengali", "ta": "Tamil", "te": "Telugu",
-    "mr": "Marathi", "ml": "Malayalam", "kn": "Kannada", "gu": "Gujarati", "pa": "Punjabi",
-    "or": "Odia", "ur": "Urdu", "sa": "Sanskrit", "ar": "Arabic", "fr": "French",
-    "de": "German", "es": "Spanish", "it": "Italian", "pt": "Portuguese", "zh": "Chinese",
-    "ja": "Japanese", "ko": "Korean", "ru": "Russian", "sv": "Swedish", "pl": "Polish",
-    "tr": "Turkish", "cs": "Czech", "fi": "Finnish", "he": "Hebrew"
-}
-# Zaban Translation API uses BCP-47 (IndicTrans2). Map short codes to BCP-47.
-LANG_CODE_TO_BCP47 = {
-    "en": "eng_Latn", "hi": "hin_Deva", "bn": "ben_Beng", "ta": "tam_Taml", "te": "tel_Telu",
-    "mr": "mar_Deva", "ml": "mal_Mlym", "kn": "kan_Knda", "gu": "guj_Gujr", "pa": "pan_Guru",
-    "or": "ory_Orya", "ur": "urd_Arab", "sa": "san_Deva", "as": "asm_Beng",
-}
+# Derived from single constant in constants to avoid mismatches.
+LANG_CODE_TO_BCP47 = {v: k for k, v in ZABAN_LANG_TO_CODE.items()}
 ALLOWED_INTENTS = ["check_balance", "recent_txn", "transfer_money",  "txn_insights", "list_beneficiaries", "unknown"]
 
 SYSTEM = """
@@ -190,7 +180,7 @@ def translate(message: str, lang_code: str = "en") -> str:
         logger.warning("ZABAN_API_KEY not set; translation requires it. Returning original.")
         return message
     try:
-        url = f"{zaban_base_url.rstrip('/')}/api/v1/translate"
+        url = f"{zaban_base_url.rstrip('/')}{ZABAN_API_PATH_TRANSLATE}"
         headers = {
             "Content-Type": "application/json",
             "X-API-Key": zaban_api_key,

--- a/service/detect_intent.py
+++ b/service/detect_intent.py
@@ -5,12 +5,11 @@ import json
 import re
 import logging
 import ollama
-from config import ollama_host, ollama_model_name, ollama_translation_model_name, sarvam_api_key
+from config import ollama_host, ollama_model_name, zaban_base_url, zaban_api_key
 from typing import Dict, Any
 from time_utils import normalize_timeframe
 import requests
 import os
-from sarvamai import SarvamAI
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -21,6 +20,12 @@ lang_map = {
     "de": "German", "es": "Spanish", "it": "Italian", "pt": "Portuguese", "zh": "Chinese",
     "ja": "Japanese", "ko": "Korean", "ru": "Russian", "sv": "Swedish", "pl": "Polish",
     "tr": "Turkish", "cs": "Czech", "fi": "Finnish", "he": "Hebrew"
+}
+# Zaban Translation API uses BCP-47 (IndicTrans2). Map short codes to BCP-47.
+LANG_CODE_TO_BCP47 = {
+    "en": "eng_Latn", "hi": "hin_Deva", "bn": "ben_Beng", "ta": "tam_Taml", "te": "tel_Telu",
+    "mr": "mar_Deva", "ml": "mal_Mlym", "kn": "kan_Knda", "gu": "guj_Gujr", "pa": "pan_Guru",
+    "or": "ory_Orya", "ur": "urd_Arab", "sa": "san_Deva", "as": "asm_Beng",
 }
 ALLOWED_INTENTS = ["check_balance", "recent_txn", "transfer_money",  "txn_insights", "list_beneficiaries", "unknown"]
 
@@ -99,9 +104,7 @@ Do NOT hallucinate.
 
 """
 
-client = SarvamAI(
-    api_subscription_key=sarvam_api_key,
-)
+
 def safe_json_parse(s: str) -> Dict[str, Any]:
     # Try direct parse
     try:
@@ -174,19 +177,37 @@ def validate_schema(result: dict) -> dict:
         "language": language,
         "confidence": confidence,
     }
-def translate(message:str, lang_code: str = "en"):
-    #lang_code = lang_map.get(lang_code,"English")
-    logger.info(f"Model: {ollama_translation_model_name}, language: {lang_code}")
-    if lang_code == "en-IN":
+def translate(message: str, lang_code: str = "en") -> str:
+    """Translate message from English to target language using Zaban Translation API. No-op for English."""
+    short = (lang_code or "en").split("-")[0].strip().lower()
+    if short == "en":
+        return message
+    target_bcp = LANG_CODE_TO_BCP47.get(short)
+    if not target_bcp:
+        logger.warning(f"Unsupported translation target: {lang_code}, returning original")
+        return message
+    if not zaban_api_key:
+        logger.warning("ZABAN_API_KEY not set; translation requires it. Returning original.")
         return message
     try:
-        id,response,lang = client.text.translate(
-            input=message,
-            source_language_code="en-IN",
-            target_language_code=f"{lang_code}",
-            speaker_gender="Female"
-        )
-        return response[1]
+        url = f"{zaban_base_url.rstrip('/')}/api/v1/translate"
+        headers = {
+            "Content-Type": "application/json",
+            "X-API-Key": zaban_api_key,
+        }
+        payload = {
+            "text": message,
+            "source_lang": "eng_Latn",
+            "target_lang": target_bcp,
+        }
+        r = requests.post(url, json=payload, headers=headers, timeout=30)
+        r.raise_for_status()
+        result = r.json()
+        out = (result.get("translated_text") or "").strip()
+        return out if out else message
+    except requests.RequestException as e:
+        logger.error(f"Zaban translation failed: {str(e)}")
+        return message
     except Exception as e:
         logger.error(f"Error during translation: {str(e)}")
         return message

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -31,4 +31,3 @@ ninja
 sqlalchemy
 psycopg2-binary
 redis
-sarvamai

--- a/service/surv.py
+++ b/service/surv.py
@@ -1,26 +1,14 @@
-from sarvamai import SarvamAI
+"""Example: text translation via detect_intent.translate (Ollama). No Sarvam."""
+from detect_intent import translate
 
-
-#SARVAM_API_KEY="sk_lz33toms_amJdXnvyWxlBQIs4OPue1yexi"
-SARVAM_API_KEY="sk_t7fvsjjb_7JsD5ZXGrEhHqjUtAQSFsCxB"
-client = SarvamAI(
-    api_subscription_key=SARVAM_API_KEY,
+# Uses Ollama (ollama_translation_model_name) for text translation
+message = (
+    "Please confirm the transaction ₹10.00 to Suresh Patil by entering the OTP "
+    "you have received on your registered mobile number"
 )
-
-response = client.text.translate(
-    #input="Please confirm your the transaction 10by entring the OTP you have recieved on your registered mobile number"
-    input="Please confirm the transaction ₹10.00 to Suresh Patil by entering the OTP you have recieved on your registered mobile number",
-    source_language_code="auto",
-    target_language_code="hi-IN",
-    speaker_gender="Female",
-    numerals_format="native"
-)
+response = translate(message, "hi")
 print(response)
-'''
-response = client.text_to_speech.convert(
-    text="Your account balacne is 2000.35",
-    target_language_code="ta-IN",
 
-)
-print(response)
-'''
+# For TTS (text-to-speech), call Zaban TTS API:
+#   POST {ZABAN_BASE_URL}/api/v1/tts with X-API-Key, JSON body: {"text": "...", "language": "hi"}
+#   Returns WAV bytes.


### PR DESCRIPTION
Update environment configuration to include Zaban API settings. Refactor audio service to utilize Zaban for speech-to-text and translation, replacing Sarvam. Adjust requirements and example usage accordingly.